### PR TITLE
[Fix]お知らせメールのリンクのURLを変更

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -7,7 +7,7 @@ class NotificationMailer < ApplicationMailer
   def warning(user, item)
     @user = user
     @item = item
-    @url = "http://ec2-13-230-253-117.ap-northeast-1.compute.amazonaws.com/users/#{@user.id}"
+    @url = "http://tim0120.com/users/#{@user.id}"
     mail to: @user.email,
          subject: "期限の3日前をお知らせします"
   end
@@ -20,7 +20,7 @@ class NotificationMailer < ApplicationMailer
   def expired(user, item)
     @user = user
     @item = item
-    @url = "http://ec2-13-230-253-117.ap-northeast-1.compute.amazonaws.com/users/#{@user.id}"
+    @url = "http://tim0120.com/users/#{@user.id}"
     mail to: @user.email,
          subject: "期限をお知らせします"
   end

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -6,7 +6,7 @@ class RegistrationMailer < ApplicationMailer
   #
   def send_when_new(user)
     @user = user
-    @url = "http://ec2-13-230-253-117.ap-northeast-1.compute.amazonaws.com/users/#{@user.id}"
+    @url = "http://tim0120.com/users/#{@user.id}"
     mail to: @user.email,
          subject: "会員登録が完了しました"
   end
@@ -18,7 +18,7 @@ class RegistrationMailer < ApplicationMailer
   #
   def send_when_update(user)
     @user = user
-    @url = "http://ec2-13-230-253-117.ap-northeast-1.compute.amazonaws.com/users/#{@user.id}"
+    @url = "http://tim0120.com/users/#{@user.id}"
     mail to: @user.email,
          subject: "会員情報を変更しました"
   end


### PR DESCRIPTION
お知らせメールのURLを
AWSの既存パブリックIPアドレスから
作成したURLに変更
